### PR TITLE
Fix -Werror warning on GHC 7.10 without breaking 7.8

### DIFF
--- a/src/Data/ArithEncode/Basic.hs
+++ b/src/Data/ArithEncode/Basic.hs
@@ -313,7 +313,7 @@ fromHashableList elems =
   let
     len = fromIntegral (length elems)
 
-    revmap :: Array Word ty
+    revmap :: Array Data.Word.Word ty
     revmap = Array.listArray (0, len) elems
 
     fwdmap = HashMap.fromList (zip elems [0..len])


### PR DESCRIPTION
A better fix would likely be to remove `-Werror`, as it seems to be
dis-recommended to put libraries on Hackage that use it, but I figured
you had some reason to keep `-Werror` in {-# GHC_OPTIONS #-} anyway.

Why a change was needed:
On GHC 7.10, Prelude starts exporting Word, making an import of Data.Word
redundant, which GHC warns about with the current warning options.

This is the smallest fix I found to make there be no warnings on 7.8 or 7.10.